### PR TITLE
Add FreeIPA and Samba-related use cases

### DIFF
--- a/freeipa-client-samba.yaml
+++ b/freeipa-client-samba.yaml
@@ -1,0 +1,18 @@
+---
+document: feeback-pipeline-use-case
+version: 1
+data:
+  id: freeipa-client-samba
+  name: Samba domain member on FreeIPA client
+  packages:
+  - freeipa-client
+  - freeipa-client-samba
+  options:
+  - no-docs
+  install_on:
+  - fedora-container-base:31
+  - fedora-container-base:rawhide
+  - fedora-empty-base:31
+  - fedora-empty-base:rawhide
+  - minimal-langpack-base:31
+  - minimal-langpack-base:rawhide

--- a/freeipa-client.yaml
+++ b/freeipa-client.yaml
@@ -1,0 +1,17 @@
+---
+document: feeback-pipeline-use-case
+version: 1
+data:
+  id: freeipa-client
+  name: FreeIPA client
+  packages:
+  - freeipa-client
+  options:
+  - no-docs
+  install_on:
+  - fedora-container-base:31
+  - fedora-container-base:rawhide
+  - fedora-empty-base:31
+  - fedora-empty-base:rawhide
+  - minimal-langpack-base:31
+  - minimal-langpack-base:rawhide

--- a/freeipa-trust-controller.yaml
+++ b/freeipa-trust-controller.yaml
@@ -1,0 +1,19 @@
+---
+document: feeback-pipeline-use-case
+version: 1
+data:
+  id: freeipa-trust-controller
+  name: FreeIPA Trust Controller
+  packages:
+  - freeipa-server
+  - freeipa-server-dns
+  - freeipa-trust-ad
+  options:
+  - no-docs
+  install_on:
+  - fedora-container-base:31
+  - fedora-container-base:rawhide
+  - fedora-empty-base:31
+  - fedora-empty-base:rawhide
+  - minimal-langpack-base:31
+  - minimal-langpack-base:rawhide

--- a/freeipa.yaml
+++ b/freeipa.yaml
@@ -1,0 +1,18 @@
+---
+document: feeback-pipeline-use-case
+version: 1
+data:
+  id: freeipa
+  name: FreeIPA server
+  packages:
+  - freeipa-server
+  - freeipa-server-dns
+  options:
+  - no-docs
+  install_on:
+  - fedora-container-base:31
+  - fedora-container-base:rawhide
+  - fedora-empty-base:31
+  - fedora-empty-base:rawhide
+  - minimal-langpack-base:31
+  - minimal-langpack-base:rawhide

--- a/samba-domain-controller.yaml
+++ b/samba-domain-controller.yaml
@@ -1,0 +1,17 @@
+---
+document: feeback-pipeline-use-case
+version: 1
+data:
+  id: samba-ad-dc
+  name: Samba AD Domain Controller
+  packages:
+  - samba-dc
+  options:
+  - no-docs
+  install_on:
+  - fedora-container-base:31
+  - fedora-container-base:rawhide
+  - fedora-empty-base:31
+  - fedora-empty-base:rawhide
+  - minimal-langpack-base:31
+  - minimal-langpack-base:rawhide


### PR DESCRIPTION
As discussed with @asamalik, add a number of FreeIPA and Samba related use cases.

They differ by intended usage:
 - a basic FreeIPA master, with CA and DNS roles
 - a basic FreeIPA trust controller (CA, DNS, trust to Active Directory)
 - a basic FreeIPA client (SSSD + a number of tools to enable NFS automount, etc)
 - Samba running as a domain member in FreeIPA domain
 - Samba running as an Active Directory domain controller on its own
