### PR TITLE
Crypto-related unwanted packages

### DIFF
--- a/eln-compose.yaml
+++ b/eln-compose.yaml
@@ -52,3 +52,9 @@ data:
   - xen-ocaml-devel
   - xen-runtime
   - xen-doc
+  - libsodium
+  - libssh2
+  - libtomcrypt
+  - python2-pycryptodomex
+  - python3-ecdsa
+  - python3-pycryptodomex


### PR DESCRIPTION
The packages added in this PR are unwanted either because they are bad cryptography implementation, unmaintained, or simply not certifiable or redundant (same functionality already present in multiple crypto packages already and we do not want to add more).

Suggestions about some of the packages:
- libsodium:
   seem to be dragged in only by dovecot to implement argon2, dovecot should be configured w/o libsdium for now, and readded later by using openssl interfaces once available there (being worked on for openssl 3.0)
- libssh2
   seem to be dragged in only by libvirt, but is not required, the libvirt config for RHEL exclude use of libssh2
- libtomcrypt
   seem to be dragged in only by mailman 2!
     please use a common library like openssl instead, if not possible please exclude mailman2
   also idm:DL1 by way of python3-dns -> python3-pycryptodomex -> libtomcrypt
- python[2|3]-pycryptodomex
  seem to be dragged by idm:DL1 and rhn-tools?
  it is an unwanted python library that reimplements cryptography, please use python-cryptography instead
- python-ecdsa
  same as above, plus python3-ecdsa is *unsafe*, as in it will easily reveal your private keys and it should *NEVER* be used in production
  this library should never be brought near RHEL at all for no reason.