### PR TITLE
Remove kernel-headers and kernel-tools

### DIFF
--- a/eln-compose.yaml
+++ b/eln-compose.yaml
@@ -43,6 +43,8 @@ data:
 
   # Just to demonstrate stuff
   unwanted_packages:
+  - kernel-headers
+  - kernel-tools
   - xen
   - xen-devel
   - xen-hypervisor


### PR DESCRIPTION
These packages are subpackages of the ARK kernel in ELN, but separate
packages in Fedora.  We need to make sure that we are using the packages
from the kernel packages in ELN.

Signed-off-by: Justin M. Forbes <jforbes@fedoraproject.org>