### PR TITLE
Remove mono

### DIFF
--- a/eln-compose.yaml
+++ b/eln-compose.yaml
@@ -43,6 +43,10 @@ data:
 
   # Just to demonstrate stuff
   unwanted_packages:
+  - mono-core
+  - mono-devel
+  - monodoc
+  - monodoc-devel
   - xen
   - xen-devel
   - xen-hypervisor


### PR DESCRIPTION
Mono hasn't been carried in RHEL and there are no plans to add it.  Exclude it from ELN for now.